### PR TITLE
修正当头像过大时，个人中心显示异常的问题

### DIFF
--- a/components/usercenter/aside.php
+++ b/components/usercenter/aside.php
@@ -9,7 +9,7 @@
         <a href="<?php echo $author_url ?>">
             <div class="text-center">
                 <img style="border-radius: 50%!important;"
-                     src="<?php echo $this->user->userAvatar ?>" class="rounded" alt="...">
+                     src="<?php echo $this->user->userAvatar ?>" class="rounded" alt="..." width="150x" height="150px">
             </div>
         </a>
         <div class="h6 m-t-xs m-b-xs"><?php _e($this->user->screenName); ?><span class="badge bg-info m-l-xs text-xs">LV<?php _e($this->user->level); ?></span></div>


### PR DESCRIPTION
现象：当头像尺寸过大时，会导致个人中心位置错乱
修改：写死头像尺寸，避免显示异常