### PR TITLE
fix: 修复了登陆和未登陆时评论框的判断逻辑

### DIFF
--- a/includes/comments.php
+++ b/includes/comments.php
@@ -95,7 +95,7 @@ function threadedComments($comments, $options)
                         <div class="form-row">
                             <div class="col-6 col-md-4">
                                 <input type="text" name="author" class="form-control form-control-sm"
-                                       placeholder="昵称" required value="<?php $this->remember('author'); ?>" />
+                                       placeholder="*昵称" required value="<?php $this->remember('author'); ?>" />
                             </div>
                             <div class="col-6 col-md-4">
                                 <input type="text" name="url" class="form-control form-control-sm"
@@ -104,7 +104,7 @@ function threadedComments($comments, $options)
                             </div>
                             <div class="col">
                                 <input type="text" name="mail" class="form-control form-control-sm"
-                                       placeholder="邮箱" value="<?php $this->remember('mail'); ?>"
+                                       placeholder="*邮箱" required value="<?php $this->remember('mail'); ?>"
                                     <?php if ($this->options->commentsRequireMail): ?> required<?php endif; ?> />
                             </div>
                         </div>


### PR DESCRIPTION
此 PR 修复了 #25 

修改说明:
1. 通过 `formdata` 的长度来判断是否登陆，再根据是否登陆来判断用户是否输入必要的信息
2. 将原本展示错误信息的 toast 封装成函数 `showCommentErr`
3. 将原本发送评论请求的业务逻辑封装成函数 `sendComment`
4. 完善了输入框的提示，输入框的 `placeholder` 在用户信息必填项前添加了`*`号
5. 有些小更改是由代码格式化引起的

**!!! 注意，此 PR 已通过测试，但是并未更新压缩文件 `onecircle.min.js` !!!**